### PR TITLE
[WIP]商品一覧表示

### DIFF
--- a/app/views/displays/index.html.haml
+++ b/app/views/displays/index.html.haml
@@ -87,7 +87,7 @@
           - @womens.each do |women|
             .displayList
               - if women.buyer_id.nil?
-                %a{href: 'static/detail_test'}
+                = link_to "/static/detail_test" do
                   .displayList--image
                     -# image_tagは商品出品機能が実装し終わったら追加する
                     = image_tag "parka.png", size: '160x150'
@@ -108,7 +108,7 @@
           - @mens.each do |man|
             .displayList
               - if man.buyer_id.nil?
-                %a{href: 'static/detail_test'}
+                = link_to "/static/detail_test" do
                   .displayList--image
                     -# image_tagは商品出品機能が実装し終わったら追加する
                     = image_tag "shoes.png", size: '160x150'
@@ -129,7 +129,7 @@
           - @toys.each do |toy|
             .displayList
               - if toy.buyer_id.nil?
-                %a{href: 'static/detail_test'}
+                = link_to "/static/detail_test" do
                   .displayList--image
                     -# image_tagは商品出品機能が実装し終わったら追加する
                     = image_tag "nuigurumi_bear.png", size: '160x150'
@@ -150,7 +150,7 @@
           - @appliances.each do |appliance|
             .displayList
               - if appliance.buyer_id.nil?
-                %a{href: 'static/detail_test'}
+                = link_to "/static/detail_test" do
                   .displayList--image
                     -# image_tagは商品出品機能が実装し終わったら追加する
                     = image_tag "smartphone.png", size: '160x150'
@@ -175,7 +175,7 @@
           - @apples.each do |apple|
             .displayList
               - if apple.buyer_id.nil?
-                %a{href: 'static/detail_test'}
+                = link_to "/static/detail_test" do
                   .displayList--image
                     -# image_tagは商品出品機能が実装し終わったら追加する
                     = image_tag "smartphone.png", size: '160x150'
@@ -196,7 +196,7 @@
           - @louis_vuittons.each do |louis_vuitton|
             .displayList
               - if louis_vuitton.buyer_id.nil?
-                %a{href: 'static/detail_test'}
+                = link_to "/static/detail_test" do
                   .displayList--image
                     -# image_tagは商品出品機能が実装し終わったら追加する
                     = image_tag "saihu.jpg", size: '160x150'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,6 @@ Rails.application.routes.draw do
   
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 #  root "displays#index"
-  root "static#regist"
+  root "displays#index"
 
 end


### PR DESCRIPTION
#What
DBからデータを取り出す商品一覧表示の実装。（images以外）
画像の取得は商品出品機能の実装が終了した後実装する。aタグをlink_toに変更済み。
index.html.haml 81-214行目該当部分。

#Why
ユーザーが商品一覧を見やすくするため実装。